### PR TITLE
another option

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -22,7 +22,7 @@ import seqexec.server._
 import seqexec.server.keywords.{DhsClient, DhsInstrument, KeywordsClient}
 import squants.time.{Seconds, Time}
 
-final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsClient[IO]) extends InstrumentSystem[IO] with DhsInstrument[IO] {
+final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsClient[IO]) extends DhsInstrument[IO] with InstrumentSystem[IO] {
 
   import Flamingos2._
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -27,8 +27,8 @@ import squants.time.{Seconds, Time}
 import scala.reflect.ClassTag
 
 final case class Ghost[F[_]: Sync](controller: GhostController[F])
-    extends InstrumentSystem[F]
-    with GdsInstrument[F] {
+    extends GdsInstrument[F]
+    with InstrumentSystem[F] {
   override val gdsClient: GdsClient[F] = controller.gdsClient
 
   override val keywordsClient: KeywordsClient[F] = this

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -30,7 +30,7 @@ import squants.space.Length
 import squants.{Seconds, Time}
 import squants.space.LengthConversions._
 
-abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends InstrumentSystem[IO] with DhsInstrument[IO] {
+abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends DhsInstrument[IO] with InstrumentSystem[IO] {
   import Gmos._
   import InstrumentSystem._
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -25,7 +25,7 @@ import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
-final case class Gnirs(controller: GnirsController, dhsClient: DhsClient[IO]) extends InstrumentSystem[IO] with DhsInstrument[IO] {
+final case class Gnirs(controller: GnirsController, dhsClient: DhsClient[IO]) extends DhsInstrument[IO] with InstrumentSystem[IO] {
   override def sfName(config: Config): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -32,8 +32,8 @@ import squants.time.Seconds
 import squants.time.Time
 
 final case class Gpi[F[_]: Sync: Timer](controller: GpiController[F])
-    extends InstrumentSystem[F]
-    with GdsInstrument[F] {
+    extends GdsInstrument[F]
+    with InstrumentSystem[F] {
   // Taken from the gpi isd
   val readoutOverhead: Time  = Seconds(4)
   val writeOverhead: Time    = Seconds(2)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -25,10 +25,10 @@ package keywords {
 
     def closeImage(id: ImageFileId): SeqActionF[F, Unit]
 
-    def keywordsBundler(implicit ev: Sync[F]): KeywordsBundler[F]
+    def keywordsBundler: KeywordsBundler[F]
   }
 
-  trait DhsInstrument[F[_]] extends KeywordsClient[F] {
+  abstract class DhsInstrument[F[_]: Sync] extends KeywordsClient[F] {
     val dhsClient: DhsClient[F]
 
     val dhsInstrumentName: String
@@ -44,7 +44,7 @@ package keywords {
         KeywordBag(StringKeyword(KeywordName.INSTRUMENT, dhsInstrumentName)),
         finalFlag = true)
 
-    def keywordsBundler(implicit ev: Sync[F]): KeywordsBundler[F] = DhsInstrument.kb[F](dhsInstrumentName)
+    def keywordsBundler: KeywordsBundler[F] = DhsInstrument.kb[F](dhsInstrumentName)
 
   }
 
@@ -74,7 +74,7 @@ package keywords {
     }
   }
 
-  trait GdsInstrument[F[_]] extends KeywordsClient[F] {
+  abstract class GdsInstrument[F[_]: Sync] extends KeywordsClient[F] {
     val gdsClient: GdsClient[F]
 
     def setKeywords(id: ImageFileId,
@@ -85,7 +85,7 @@ package keywords {
     def closeImage(id: ImageFileId): SeqActionF[F, Unit] =
       gdsClient.closeObservation(id)
 
-    def keywordsBundler(implicit ev: Sync[F]): KeywordsBundler[F] = GdsInstrument.kb[F]
+    def keywordsBundler: KeywordsBundler[F] = GdsInstrument.kb[F]
   }
 
   sealed trait KeywordType extends Product with Serializable

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -27,7 +27,7 @@ import squants.Time
 import squants.time.TimeConversions._
 
 final case class Niri(controller: NiriController, dhsClient: DhsClient[IO])
-  extends InstrumentSystem[IO] with DhsInstrument[IO] {
+  extends DhsInstrument[IO] with InstrumentSystem[IO] {
 
   import Niri._
 


### PR DESCRIPTION
This makes `KeywordsClient` unconstrained on `F` at the cost of turning `DhsInstrument` and `GdsInstrument` into abstract classes. I think I like it better. What do you think?